### PR TITLE
initializer clean up

### DIFF
--- a/config/initializers/candidate_authorities.rb
+++ b/config/initializers/candidate_authorities.rb
@@ -1,3 +1,0 @@
-# Import candidate names authority
-
-# This functionality has been moved to script/import_candidates. Run that script if you need the candidate authorities.

--- a/config/initializers/office_authorities.rb
+++ b/config/initializers/office_authorities.rb
@@ -1,31 +1,13 @@
 # Import the offices authority data
 
 require 'net/http'
-uri_for_offices_file = 'https://dl.tufts.edu/file_assets/generic/tufts:MS115.003.001.00003.00001/0'
 
 filename = Rails.root.join('tmp', 'offices.xml')
 
-if (Rails.env.development? || Rails.env.test?) && File.exist?(filename)
-  Rails.logger.info "Skipping download, using existing offices authority: #{filename}"
-  puts "Skipping download, using existing offices authority: #{filename}"
+if File.exist?(filename)
+  Rails.logger.info "Using existing offices authority: #{filename}"
 else
-  # Download the offices authority file
-  Rails.logger.info "Downloading offices authority from #{uri_for_offices_file}"
-  puts "Downloading offices authority from #{uri_for_offices_file}"
-
-  response = Net::HTTP.get_response(URI(uri_for_offices_file))
-
-  if response.code == '200'
-    File.open(filename, 'w') do |file|
-      file.write response.body.force_encoding('UTF-8')
-    end
-  else
-    msg = "Warning: Could not load #{uri_for_offices_file} (HTTP response: #{response.code}). Attempting to read local cached copy."
-
-    puts msg
-    Rails.logger.warn msg
-  end
-
+  Rails.logger.warn "ERROR: Office authority file missing."
 end
 
 # Load the offices

--- a/config/initializers/office_authorities.rb
+++ b/config/initializers/office_authorities.rb
@@ -7,7 +7,7 @@ filename = Rails.root.join('tmp', 'offices.xml')
 if File.exist?(filename)
   Rails.logger.info "Using existing offices authority: #{filename}"
 else
-  Rails.logger.warn "ERROR: Office authority file missing."
+  Rails.logger.error "Office authority file missing, looking for file: #{filename}"
 end
 
 # Load the offices

--- a/config/initializers/party_authorities.rb
+++ b/config/initializers/party_authorities.rb
@@ -8,7 +8,7 @@ filename = Rails.root.join('tmp', 'party-authority.xml')
 if File.exist?(filename)
   Rails.logger.info "Using existing parties authority: #{filename}"
 else
-  Rails.logger.warn "ERROR: Party authority file missing."
+  Rails.logger.error "Party authority file missing, looking for file: #{filename}"
 end
 
 # Load the parties

--- a/config/initializers/party_authorities.rb
+++ b/config/initializers/party_authorities.rb
@@ -2,29 +2,13 @@
 
 require 'net/http'
 
-uri_for_party_file = 'https://dl.tufts.edu/file_assets/generic/tufts:party-authority/0'
 filename = Rails.root.join('tmp', 'party-authority.xml')
 
-# Download the party authority file
-if (Rails.env.development? || Rails.env.test?) && File.exist?(filename)
-  Rails.logger.info "Skipping download, using existing party authority: #{filename}"
-  puts "Skipping download, using existing party authority: #{filename}"
+
+if File.exist?(filename)
+  Rails.logger.info "Using existing parties authority: #{filename}"
 else
-  Rails.logger.info "Downloading party authority from #{uri_for_party_file}"
-  puts "Downloading party authority from #{uri_for_party_file}"
-
-  response = Net::HTTP.get_response(URI(uri_for_party_file))
-
-  if response.code == '200'
-    File.open(filename, 'w') do |file|
-      file.write response.body.force_encoding('UTF-8')
-    end
-  else
-    msg = "Warning: Could not load #{uri_for_party_file} (HTTP response: #{response.code}). Attempting to read local cached copy."
-
-    puts msg
-    Rails.logger.warn msg
-  end
+  Rails.logger.warn "ERROR: Party authority file missing."
 end
 
 # Load the parties

--- a/config/initializers/state_authorities.rb
+++ b/config/initializers/state_authorities.rb
@@ -7,7 +7,7 @@ filename = Rails.root.join('tmp', 'state-authorities.xml')
 if File.exist?(filename)
   Rails.logger.info "Using existing states authority: #{filename}"
 else
-  Rails.logger.warn "ERROR: State authority file missing."
+  Rails.logger.error "State authority file missing, looking for file: #{filename}"
 end
 
 # Load the states

--- a/config/initializers/state_authorities.rb
+++ b/config/initializers/state_authorities.rb
@@ -1,29 +1,13 @@
 # Import the state authority data
 
 require 'net/http'
-uri_for_state_file = 'https://dl.tufts.edu/file_assets/generic/tufts:state-authority/0'
 
 filename = Rails.root.join('tmp', 'state-authorities.xml')
 
-if (Rails.env.development? || Rails.env.test?) && File.exist?(filename)
-  Rails.logger.info "Skipping download, using existing state authority: #{filename}"
-  puts "Skipping download, using existing state authority: #{filename}"
+if File.exist?(filename)
+  Rails.logger.info "Using existing states authority: #{filename}"
 else
-  Rails.logger.info "Downloading state authority from #{uri_for_state_file}"
-  puts "Downloading state authority from #{uri_for_state_file}"
-
-  response = Net::HTTP.get_response(URI(uri_for_state_file))
-
-  if response.code == '200'
-    File.open(filename, 'w') do |file|
-      file.write response.body.force_encoding('UTF-8')
-    end
-  else
-    msg = "Warning: Could not load #{uri_for_state_file} (HTTP response: #{response.code}). Attempting to read local cached copy."
-
-    puts msg
-    Rails.logger.warn msg
-  end
+  Rails.logger.warn "ERROR: State authority file missing."
 end
 
 # Load the states

--- a/script/import_candidates
+++ b/script/import_candidates
@@ -5,7 +5,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '../config/environment.rb'))
 
 ####### Overarching variables #######
-candidate_source = 'https://dl.tufts.edu/file_assets/generic/tufts:MS115.003.001.00002.00001/0'
 candidate_file = Rails.root.join('tmp', 'candidates.xml')
 
 ####### Functions #######
@@ -33,30 +32,6 @@ def connect_to_solr
     false
   else
     RSolr.connect(url: solr_url)
-  end
-end
-
-#@function
-# Retrieves the authorities fom dl.tufts.
-#
-# @param {str} source_uri
-#   The uri of the authority xml file.
-# @param {str} dest_file
-#   The file to copy the authorities into.
-def get_authority_file(source_uri, dest_file)
-  require 'net/http'
-  log_and_puts("Downloading candidate names authority from #{source_uri}", :info)
-
-  response = Net::HTTP.get_response(URI(source_uri))
-  case(response)
-    when Net::HTTPSuccess then
-      File.open(dest_file, 'w') do |file|
-        file.write response.body
-      end
-    when Net::HTTPRedirection then
-      get_authority_file(response['location'], dest_file)
-    else
-      log_and_puts("Warning: Could not load #{source_uri} (HTTP response: #{response.code}). Attempting to read local cached copy.")
   end
 end
 
@@ -98,12 +73,6 @@ conn = connect_to_solr
 unless(conn)
   log_and_puts("Failed connecting to Solr. Check connection settings.")
   exit 1
-end
-
-if (Rails.env.development? || Rails.env.test?) && File.exist?(candidate_file)
-  log_and_puts("Skipping candidate authority file download", :info)
-else
-  get_authority_file(candidate_source, candidate_file)
 end
 
 if(File::readable?(candidate_file))


### PR DESCRIPTION
Initializers hadn't been updated since this project wrapped, and we migrated off Fedora 3.  There used to be a need for these to be updated from Fedora as they were updated during the project, but now they're just static files and so that dependency between projects doesn't need to exist, nor the overhead to maintain it.